### PR TITLE
Fix deprecated usage of .load()

### DIFF
--- a/src/jquery.dotdotdot.js
+++ b/src/jquery.dotdotdot.js
@@ -747,6 +747,6 @@ jQuery(document).ready(function($) {
 });
 
 //Updating elements (if any) on window.load event
-jQuery(window).load(function(){
+jQuery(window).on('load', function(){
 	jQuery(".dot-ellipsis.dot-load-update").trigger("update.dot");
 });


### PR DESCRIPTION
.load() is deprecated since jQuery 1.8
http://api.jquery.com/load-event/