### PR TITLE
Remove ellipsis parent if empty

### DIFF
--- a/src/jquery.dotdotdot.js
+++ b/src/jquery.dotdotdot.js
@@ -509,7 +509,14 @@
 				setTextContent( e, txt );
 				if ( afterLength && after )
 				{
+					var $parent = after.parent();
+
 					$(e).parent().append( after );
+
+					if ( !$.trim( $parent.html() ) )
+					{
+						$parent.remove();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
I have the ellipsis element inside the content I want to truncate. Sometimes it happens that its parent remains in the truncated element but it is empty. Remove it in that case.