### PR TITLE
JQuery defines the AMD module 'jquery', but not 'jQuery'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ gulp.task( 'js', function() {
 		.pipe( rename({ suffix: '.min' }) )
 		.pipe( gulp.dest( 'src' ) )
 		.pipe( umd({
-			dependencies: function() { return [ 'jQuery' ]; },
+			dependencies: function() { return [ 'jquery' ]; },
 			exports: function() { return true; },
 			namespace: sanitizeNamespaceForUmd
 		}))


### PR DESCRIPTION
JQuery defines its AMD module as jquery, i.e. with this code (version 1.12)

`
if ( typeof define === "function" && define.amd ) {
define( "jquery", [], function() {
return jQuery;
} );
}
`

Therefore dotdotdot should use the default module name.
