### PR TITLE
fixed UMD import code to eliminate duplicate jQuery modules

### DIFF
--- a/src/jquery.dotdotdot.min.umd.js
+++ b/src/jquery.dotdotdot.min.umd.js
@@ -1,8 +1,8 @@
 ;(function(root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jQuery'], factory);
+    define(['jquery'], factory);
   } else if (typeof exports === 'object') {
-    module.exports = factory(require('jQuery'));
+    module.exports = factory(require('jquery'));
   } else {
     root.jquery_dotdotdot_min_js = factory(root.jQuery);
   }


### PR DESCRIPTION
When using jQuery.dotdotdot alongside other plugins like Validate and MaskedInput i got a warning because the jQuery that dotdotdot is requiring is not the same as any other package, it's a casing problem where "jQuery" is not the same as "jquery" on case sensitive systems.

I have changed the casing so that it's in line with other jQuery packages, removing this issue.