### PR TITLE
Making jQuery.dotdotdot compatible with jQuery 3.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
     "README.md"
   ],
   "dependencies": {
-    "jquery": ">= 1.4.3"
+    "jquery": ">= 1.7"
   }
 }

--- a/dotdotdot.jquery.json
+++ b/dotdotdot.jquery.json
@@ -13,6 +13,6 @@
 		"url": "http://opensource.org/licenses/MIT"
 	}],
 	"dependencies": {
-		"jquery": ">= 1.4.3"
+		"jquery": ">= 1.7"
 	}
 }

--- a/src/jquery.dotdotdot.js
+++ b/src/jquery.dotdotdot.js
@@ -616,7 +616,7 @@ You can add one or several CSS classes to HTML elements to automatically invoke 
 
 */
 
-jQuery(function() {
+jQuery(function($) {
     //We only invoke jQuery.dotdotdot on elements that have dot-ellipsis class
     $(".dot-ellipsis").each(function() {
         //Checking if update on window resize required

--- a/src/jquery.dotdotdot.js
+++ b/src/jquery.dotdotdot.js
@@ -44,7 +44,7 @@
         }
 
         $dot.bind_events = function() {
-            $dot.bind(
+            $dot.on(
                 'update.dot',
                 function(e, c) {
                     $dot.removeClass("is-truncated");
@@ -119,7 +119,7 @@
                     return trunc;
                 }
 
-            ).bind(
+            ).on(
                 'isTruncated.dot',
                 function(e, fn) {
                     e.preventDefault();
@@ -131,7 +131,7 @@
                     return conf.isTruncated;
                 }
 
-            ).bind(
+            ).on(
                 'originalContent.dot',
                 function(e, fn) {
                     e.preventDefault();
@@ -143,7 +143,7 @@
                     return orgContent;
                 }
 
-            ).bind(
+            ).on(
                 'destroy.dot',
                 function(e) {
                     e.preventDefault();
@@ -164,7 +164,7 @@
         }; //	/bind_events
 
         $dot.unbind_events = function() {
-            $dot.unbind('.dot');
+            $dot.off('.dot');
             return $dot;
         }; //	/unbind_events
 
@@ -175,7 +175,7 @@
                     _wWidth = $window.width(),
                     _wHeight = $window.height();
 
-                $window.bind(
+                $window.on(
                     'resize.dot' + conf.dotId,
                     function() {
                         if (_wWidth != $window.width() || _wHeight != $window.height() || !opts.windowResizeFix) {
@@ -211,7 +211,7 @@
             return $dot;
         };
         $dot.unwatch = function() {
-            $(window).unbind('resize.dot' + conf.dotId);
+            $(window).off('resize.dot' + conf.dotId);
             if (watchInt) {
                 clearInterval(watchInt);
             }
@@ -598,25 +598,25 @@ You can add one or several CSS classes to HTML elements to automatically invoke 
 ### Usage examples
 *Adding jQuery.dotdotdot to element*
 
-	<div class="dot-ellipsis">
-	<p>Lorem Ipsum is simply dummy text.</p>
-	</div>
+    <div class="dot-ellipsis">
+    <p>Lorem Ipsum is simply dummy text.</p>
+    </div>
 
 *Adding jQuery.dotdotdot to element with update on window resize*
 
-	<div class="dot-ellipsis dot-resize-update">
-	<p>Lorem Ipsum is simply dummy text.</p>
-	</div>
+    <div class="dot-ellipsis dot-resize-update">
+    <p>Lorem Ipsum is simply dummy text.</p>
+    </div>
 
 *Adding jQuery.dotdotdot to element with predefined height of 50px*
 
-	<div class="dot-ellipsis dot-height-50">
-	<p>Lorem Ipsum is simply dummy text.</p>
-	</div>
+    <div class="dot-ellipsis dot-height-50">
+    <p>Lorem Ipsum is simply dummy text.</p>
+    </div>
 
 */
 
-jQuery(document).ready(function($) {
+jQuery(function() {
     //We only invoke jQuery.dotdotdot on elements that have dot-ellipsis class
     $(".dot-ellipsis").each(function() {
         //Checking if update on window resize required


### PR DESCRIPTION
In order to make this plugin compatible with jQuery 3.x deprecated syntax have been replaced.
Namely bind/unbind with on/off -> see https://jquery.com/upgrade-guide/3.0/#deprecated-bind-and-delegate

Introducing on and off would need a jQuery 1.7 or higher

Info: Only the source file has been edited. Minified files are not generated in this pull request