### PR TITLE
Fix a couple of issues in the watch method

### DIFF
--- a/src/jquery.dotdotdot.js
+++ b/src/jquery.dotdotdot.js
@@ -248,7 +248,7 @@
 
 						if ( that.watchInterval )
 						{
-							clearInterval( that.watchInterval );
+							clearTimeout( that.watchInterval );
 						}
 						that.watchInterval = setTimeout(
 							function() {

--- a/src/jquery.dotdotdot.js
+++ b/src/jquery.dotdotdot.js
@@ -272,7 +272,7 @@
 			}
 			else
 			{
-				var oldSizes,
+				var oldSizes = {},
 					newSizes;
 
 				this.watchInterval = setInterval(
@@ -285,7 +285,7 @@
 								'height'	: that.$dot.innerHeight()
 							};
 
-							if ( oldSizes.width != newSizes.width || oldSizes.height != oldSizes.height )
+							if ( oldSizes.width != newSizes.width || oldSizes.height != newSizes.height )
 							{
 								that.truncate();
 							}


### PR DESCRIPTION
In the `watch` method there were a couple of errors.

- The `oldSizes` variable was not initialized causing
  >`oldSizes` is undefined 

   when trying to access its `.width` and `.height` properties.

- One of the checks is made against itself so it is moot `oldSizes.height != oldSizes.height`
- Using `clearInterval` when the variable is filled from `setTimeout`
