### PR TITLE
Fix resizing of hidden elements

### DIFF
--- a/src/jquery.dotdotdot.js
+++ b/src/jquery.dotdotdot.js
@@ -248,7 +248,12 @@
 						that.watchTimeout = setTimeout(
 							function() {
 
-								oldSizes = that._watchSizes( oldSizes, $wndw, 'width', 'height' );
+								var newSizes = that._watchSizes( oldSizes, $wndw, 'width', 'height' );
+
+								if (newSizes)
+								{
+									oldSizes = newSizes;
+								}
 
 							}, 100
 						);
@@ -261,7 +266,12 @@
 				this.watchInterval = setInterval(
 					function()
 					{
-						oldSizes = that._watchSizes( oldSizes, that.$dot, 'innerWidth', 'innerHeight' );
+						var newSizes = that._watchSizes( oldSizes, that.$dot, 'innerWidth', 'innerHeight' );
+
+						if (newSizes)
+						{
+							oldSizes = newSizes;
+						}
 
 					}, 500
 				);


### PR DESCRIPTION
`_watchSizes` returns the current size of an element. It returns `undefined` if the element in question is hidden, which makes sense. However, the result of `_watchSizes` is always assigned to `oldSizes`. The intent of variable `oldSizes` is to keep track of the previous size of an element, so the code can check if there's a difference in size later on. `oldSizes` should never be `undefined`. This change makes sure of that.